### PR TITLE
bug: @result in Build class not present.

### DIFF
--- a/lib/hudson-remote-api/build.rb
+++ b/lib/hudson-remote-api/build.rb
@@ -21,6 +21,7 @@ module Hudson
 			build_info_xml = get_xml(@xml_api_build_info_path)
       build_info_doc = REXML::Document.new(build_info_xml)
 
+      @result = build_info_doc.elements["/freeStyleBuild/result"].text
       if !build_info_doc.elements["/freeStyleBuild/changeSet"].nil?
           build_info_doc.elements.each("/freeStyleBuild/changeSet/revision"){|e| @revisions[e.elements["module"].text] = e.elements["revision"].text }
       end


### PR DESCRIPTION
Hi.
@result in Build class is not present.(It return nil)
I write patch (however, test code is not attached), If you need, please apply this.

Thanks.
