### PR TITLE
Added CSRF crumb fetching logic

### DIFF
--- a/lib/hudson-remote-api.rb
+++ b/lib/hudson-remote-api.rb
@@ -21,7 +21,11 @@ module Hudson
     end
     
     load_xml_api
-    
+
+    def self.url_for(path)
+      File.join Hudson[:url], path
+    end
+
     def self.get_xml(url)
       uri = URI.parse(url)
       host = uri.host
@@ -57,6 +61,7 @@ module Hudson
       request = Net::HTTP::Post.new(path)
       request.basic_auth(Hudson[:user], Hudson[:password]) if Hudson[:user] and Hudson[:password]
       request.set_form_data(data)
+      request.add_field(crumb.name, crumb.value) if crumb
       Net::HTTP.new(host, port).start{|http| http.request(request)}
     end
     
@@ -73,6 +78,7 @@ module Hudson
       request = Net::HTTP::Post.new(path)
       request.basic_auth(Hudson[:user], Hudson[:password]) if Hudson[:user] and Hudson[:password]
       request.set_form_data(data) if data
+      request.add_field(crumb.name, crumb.value) if crumb
       request.body = xml
       Net::HTTP.new(host, port).start{|http| http.request(request)}
     end
@@ -80,6 +86,30 @@ module Hudson
     def send_xml_post_request(url, xml, data=nil)
       self.class.send_xml_post_request(url, xml, data)
     end
+    
+    
+    
+    def self.crumb
+      @@apiCrumb ||= nil
+    end
+    
+    def self.fetch_crumb
+      body = get_xml(url_for '/crumbIssuer/api/xml')
+      doc = REXML::Document.new(body)
+      
+      crumbValue = doc.elements['/defaultCrumbIssuer/crumb'] or begin
+        $stderr.puts "Failure fetching crumb value from server"
+        return
+      end
+      
+      crumbName = doc.elements['/defaultCrumbIssuer/crumbRequestField'] or begin
+        $stderr.puts "Failure fetching crumb field name from server"
+        return
+      end
+      
+      @@apiCrumb = Struct.new(:name,:value).new(crumbName.text,crumbValue.text)
+    end
+    
   end
 end
 


### PR DESCRIPTION
Added crumb fetching logic to Hudson::HudsonObject. 

send_post_request() and send_xml_post_request() will add the crumb to the request header if it has been previously set. 

Crumb is not automatically fetched; user must explicitly call Hudson::HudsonObject::fetch_crumb.

The crumb is required in the header for post actions if the Hudson server has CSRF protection enabled. http://wiki.hudson-ci.org/display/HUDSON/Monitoring+external+jobs#Monitoringexternaljobs-CSRFProtection

Example:

```
Hudson[:user] = user
Hudson[:password] = secret
Hudson::Job.fetch_crumb   # << this is the new method
job = Hudson::Job.new('someExistingJob')
job.config = job.config.gsub('from','to')
job.update
```
