### PR TITLE
ssl, and parsing of urls

### DIFF
--- a/lib/hudson-remote-api.rb
+++ b/lib/hudson-remote-api.rb
@@ -15,6 +15,16 @@ module Hudson
   # Base class for all Hudson objects
   class HudsonObject
     
+    def self.hudson_request(uri,request)
+       Net::HTTP.start(uri.host, uri.port) do |http| 
+        http = Net::HTTP.new(uri.host, uri.port)
+        if uri.scheme == 'https'
+          http.use_ssl = true
+          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        end
+        http.request(request)
+      end
+    end
     
     def self.load_xml_api
       @@hudson_xml_api_path = File.join(Hudson[:url], "api/xml")
@@ -35,14 +45,7 @@ module Hudson
       request = Net::HTTP::Get.new(path)
       request.basic_auth(Hudson[:user], Hudson[:password]) if Hudson[:user] and Hudson[:password]
       request['Content-Type'] = "text/xml"
-      response = Net::HTTP.start(host, port) do |http| 
-        http = Net::HTTP.new(uri.host, uri.port)
-        if uri.scheme == 'https'
-          http.use_ssl = true
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        end
-        http.request(request)
-      end
+      response = hudson_request(uri,request)
 
       if response.is_a?(Net::HTTPSuccess) or response.is_a?(Net::HTTPRedirection)
         encoding = response.get_fields("Content-Encoding")
@@ -70,15 +73,7 @@ module Hudson
       request.basic_auth(Hudson[:user], Hudson[:password]) if Hudson[:user] and Hudson[:password]
       request.set_form_data(data)
       request.add_field(crumb.name, crumb.value) if crumb
-      Net::HTTP.new(host, port).start{|http| http.request(request)}
-      Net::HTTP.start(host, port) do |http|
-        http = Net::HTTP.new(uri.host, uri.port)
-        if uri.scheme == 'https'
-          http.use_ssl = true
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        end
-        http.request(request)
-      end
+      hudson_request(uri,request)
     end
     
     def send_post_request(url, data={})
@@ -96,14 +91,7 @@ module Hudson
       request.set_form_data(data) if data
       request.add_field(crumb.name, crumb.value) if crumb
       request.body = xml
-      Net::HTTP.start(host, port) do |http|
-        http = Net::HTTP.new(uri.host, uri.port)
-        if uri.scheme == 'https'
-          http.use_ssl = true
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        end
-        http.request(request)
-      end
+      hudson_request(uri,request)
     end
     
     def send_xml_post_request(url, xml, data=nil)


### PR DESCRIPTION
Extended ssl support for the rest of the functions, also found a bug where you could not access a job if it has spaces in it, so modified the uri to fix that. Also broke out the http request to a hudson_request with the ssl logic, to avoid repetition. 
