### PR TITLE
Updating gemspec info

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ begin
     gemspec.homepage = "http://github.com/Druwerd/hudson-remote-api"
     gemspec.authors = ["Dru Ibarra"]
     gemspec.rubyforge_project = gemspec.name
+    gemspec.files = Dir.glob(File.join('lib/**', '*'))
   end
   Jeweler::GemcutterTasks.new
 rescue LoadError

--- a/hudson-remote-api.gemspec
+++ b/hudson-remote-api.gemspec
@@ -9,19 +9,14 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Dru Ibarra"]
-  s.date = "2012-07-14"
+  s.date = "2013-06-28"
   s.description = "Connect to Hudson's remote web API"
   s.email = "Druwerd@gmail.com"
   s.extra_rdoc_files = [
     "LICENSE",
-    "README"
+    "README.md"
   ]
   s.files = [
-    "LICENSE",
-    "README",
-    "Rakefile",
-    "VERSION",
-    "hudson-remote-api.gemspec",
     "lib/hudson-remote-api.rb",
     "lib/hudson-remote-api/build.rb",
     "lib/hudson-remote-api/build_queue.rb",
@@ -29,12 +24,7 @@ Gem::Specification.new do |s|
     "lib/hudson-remote-api/errors.rb",
     "lib/hudson-remote-api/job.rb",
     "lib/hudson-remote-api/multicast.rb",
-    "lib/hudson-remote-api/new_job_config.xml",
-    "test/test_hudson_build.rb",
-    "test/test_hudson_build_queue.rb",
-    "test/test_hudson_config.rb",
-    "test/test_hudson_job.rb",
-    "test/test_hudson_multicast.rb"
+    "lib/hudson-remote-api/new_job_config.xml"
   ]
   s.homepage = "http://github.com/Druwerd/hudson-remote-api"
   s.require_paths = ["lib"]
@@ -46,9 +36,12 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<rake>, [">= 0"])
     else
+      s.add_dependency(%q<rake>, [">= 0"])
     end
   else
+    s.add_dependency(%q<rake>, [">= 0"])
   end
 end
 


### PR DESCRIPTION
Updating the Rakefile for Jeweler to only use the lib/ folder so that extra files aren't included (Tests, fixtures, etc).

Re-generated the gemspec.
