### PR TITLE
enable proxy access

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Hudson[:password] = 'password'
 
 # To turn off checking for crumbIssuer
 Hudson[:crumb] = false
+
+# To turn on proxy access
+Hudson[:proxy_host] = 'your-proxy-host'
+Hudson[:proxy_port] = 8888
+
 ```
 ## Usage:
 

--- a/lib/hudson-remote-api/config.rb
+++ b/lib/hudson-remote-api/config.rb
@@ -2,7 +2,15 @@ require File.dirname(__FILE__) + '/multicast.rb'
 
 module Hudson
   # set default settings
-  @@settings = {:url => 'http://localhost:8080', :user => nil, :password => nil, :version => nil, :crumb => true}
+  @@settings = {
+    :url => 'http://localhost:8080', 
+    :user => nil, 
+    :password => nil, 
+    :version => nil, 
+    :crumb => true,
+    :proxy_host => nil,
+    :proxy_port => nil
+  }
   
   def self.[](param)
     return @@settings[param]

--- a/test/test_hudson_config.rb
+++ b/test/test_hudson_config.rb
@@ -31,5 +31,12 @@ class TestHudsonConfig < Test::Unit::TestCase
     Hudson.settings = new_settings
     assert_equal(Hudson[:crumb], false)
   end
+
+  def test_proxy_setting
+    new_settings = {:url => 'test.com', :user => 'test', :password => 'test', :version => '1.00', :proxy_host => 'test-proxy.com', :proxy_port => 9876}
+    Hudson.settings = new_settings
+    assert_equal(Hudson[:proxy_host], 'test-proxy.com')
+    assert_equal(Hudson[:proxy_port], 9876)
+  end
   
 end


### PR DESCRIPTION
Some Jenkins servers might be run under proxy environment.  
So I added "Hudson[:proxy_host] and Hudson[:proxy_port]" config and enable proxy access.

Thanks.
